### PR TITLE
Alterações reunião 2020-03-07

### DIFF
--- a/SulpassoMobile/app/build.gradle
+++ b/SulpassoMobile/app/build.gradle
@@ -9,7 +9,7 @@ android{
         minSdkVersion 16
         targetSdkVersion 28
         versionCode 934
-        versionName "1.99V9"
+        versionName "2.000.0003"
     }
     buildTypes {
         release {

--- a/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/controle/ConsultaClientes.java
+++ b/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/controle/ConsultaClientes.java
@@ -93,6 +93,9 @@ public class ConsultaClientes implements br.com.sulpasso.sulpassomobile.controle
     {
         CorteDataAccess cda = new CorteDataAccess(this.ctx);
 
+        try { this.clientes.clear(); }
+        catch (Exception e) { this.clientes = new ArrayList<Cliente>(); }
+
         try
         {
             this.cortes = cda.getAll();
@@ -117,19 +120,19 @@ public class ConsultaClientes implements br.com.sulpasso.sulpassomobile.controle
 
         for(ItensVendidos i : ic)
         {
-            Item it;
+            //Item it;
             str_ret = "";
             str_ret += i.getItem();
 
             try
             {
-                it = ida.buscarItemCodigo(i.getItem());
+                //it = ida.buscarItemCodigo(i.getItem());
 
-                str_ret += " - " + ms.comDireita(it.getReferencia(), " ", 10).trim() + " . " +
-                        ms.comDireita(it.getDescricao(), " ", 25).trim() + " . " +
-                        ms.comDireita(it.getComplemento(), " ", 15).trim() + " - ";
+                str_ret += " - " + ms.comDireita(i.getReferencia(), " ", 10).trim() + " . " +
+                        ms.comDireita(i.getDescricao(), " ", 25).trim() + " . " +
+                        ms.comDireita(i.getComplemento(), " ", 15).trim() + " - ";
             }
-            catch (GenercicException e) { str_ret += " -  .  .  - "; }
+            catch (Exception e) { str_ret += " -  .  .  - "; }
 
             str_ret += i.getQuantidade();
 

--- a/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/controle/ConsultarPedidos.java
+++ b/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/controle/ConsultarPedidos.java
@@ -385,6 +385,8 @@ public class ConsultarPedidos
                 for(Venda v : this.todas)
                 {
                     total += v.getValor();
+                    volume += v.getVolume();
+                    contribuicao += v.getContribuicao();
                 }
                 break;
             case 1:
@@ -392,6 +394,8 @@ public class ConsultarPedidos
                 for(Venda v : this.enviadas)
                 {
                     total += v.getValor();
+                    volume += v.getVolume();
+                    contribuicao += v.getContribuicao();
                 }
                 break;
             case 2:
@@ -399,6 +403,8 @@ public class ConsultarPedidos
                 for(Venda v : this.naoEnviadas)
                 {
                     total += v.getValor();
+                    volume += v.getVolume();
+                    contribuicao += v.getContribuicao();
                 }
                 break;
         }

--- a/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/controle/ConsultarProdutos.java
+++ b/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/controle/ConsultarProdutos.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 
 import br.com.sulpasso.sulpassomobile.exeption.GenercicException;
 import br.com.sulpasso.sulpassomobile.modelo.Gravosos;
+import br.com.sulpasso.sulpassomobile.modelo.Grupo;
 import br.com.sulpasso.sulpassomobile.modelo.Item;
 import br.com.sulpasso.sulpassomobile.persistencia.queries.ItemDataAccess;
 import br.com.sulpasso.sulpassomobile.util.Enumarations.TiposBuscaItens;
@@ -451,5 +452,10 @@ public class ConsultarProdutos
     public Boolean verifyItens()
     {
         return this.lista != null && this.lista.size() > 0;
+    }
+
+    public Grupo getGrupoItem(int item)
+    {
+        return this.ida.getGrupoItem(item);
     }
 }

--- a/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/controle/SalvarPedido.java
+++ b/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/controle/SalvarPedido.java
@@ -71,7 +71,7 @@ public class SalvarPedido
         else return false;
     }
 
-    public Boolean salvarPedido(Context ctx, Venda venda)
+    public Boolean salvarPedido(Context ctx, Venda venda/*, passar motivo venda (justificativa)*/)
     {
         VendaDataAccess vda = new VendaDataAccess(ctx);
         VisitaDataAccess vida = new VisitaDataAccess(ctx);
@@ -81,6 +81,10 @@ public class SalvarPedido
         v.setData(venda.getData());
         v.setHora(venda.getHora());
         v.setMotivo(500);
+
+        /*
+        TODO: Alterar para acrescentar o salvamento dos valores de Volume e contribuição no pedido
+         */
 
         try
         {

--- a/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/controle/VendaDireta.java
+++ b/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/controle/VendaDireta.java
@@ -258,4 +258,5 @@ public class VendaDireta extends EfetuarPedidos {
     public Boolean mostraFlexItem(){ return false; }
 
     public Boolean mostraFlexVenda(){ return false; }
+    public boolean buscarPorCampanhas(int pos){return false;}
 }

--- a/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/modelo/CampanhaGrupo.java
+++ b/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/modelo/CampanhaGrupo.java
@@ -58,4 +58,23 @@ public class CampanhaGrupo
                 " Qtd.:" + quantidade +
                 " Desc.:" + desconto;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CampanhaGrupo)) return false;
+
+        CampanhaGrupo that = (CampanhaGrupo) o;
+
+        if (getQuantidade() != that.getQuantidade()) return false;
+        return getGrupo().equals(that.getGrupo());
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = getGrupo().hashCode();
+        result = 31 * result + getQuantidade();
+        return result;
+    }
 }

--- a/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/modelo/CampanhaProduto.java
+++ b/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/modelo/CampanhaProduto.java
@@ -11,6 +11,7 @@ public class CampanhaProduto
     private int quantidade;
     private float desconto;
     private List<Integer> itens;
+    private List<String> itensDesc;
     private float descontoAplicado;
     private float quantidadeVendida;
 
@@ -38,6 +39,10 @@ public class CampanhaProduto
 
     public void setQuantidadeVendida(float quantidadeVendida) { this.quantidadeVendida = quantidadeVendida; }
 
+    public List<String> getItensDesc() { return itensDesc; }
+
+    public void setItensDesc(List<String> itensDesc) { this.itensDesc = itensDesc; }
+
     @Override
     public String toString()
     {
@@ -59,6 +64,9 @@ public class CampanhaProduto
             sBuilder.append(codigo);
             sBuilder.append(" - ");
             sBuilder.append(i);
+            sBuilder.append(" - ");
+            sBuilder.append(itensDesc.get(this.itens.indexOf(i)));
+            sBuilder.append(" -\n ");
             sBuilder.append(" Qtd.:");
             sBuilder.append(quantidade);
             sBuilder.append(" Desc.:");

--- a/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/modelo/Grupo.java
+++ b/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/modelo/Grupo.java
@@ -44,4 +44,25 @@ public class Grupo
                 " - " + divisao +
                 " - " + descricao;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Grupo)) return false;
+
+        Grupo grupo1 = (Grupo) o;
+
+        if (getGrupo() != grupo1.getGrupo()) return false;
+        if (getSubGrupo() != grupo1.getSubGrupo()) return false;
+        return getDivisao() == grupo1.getDivisao();
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = getGrupo();
+        result = 31 * result + getSubGrupo();
+        result = 31 * result + getDivisao();
+        return result;
+    }
 }

--- a/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/modelo/ItensVendidos.java
+++ b/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/modelo/ItensVendidos.java
@@ -22,6 +22,9 @@ public class ItensVendidos
     private boolean descontoCampanha;
     private float valorMinimo;
     private float quantidadeEspecifica;
+    private float peso;
+
+    private float contribuicao;
 
     private String descricao;
     private String referencia;
@@ -95,6 +98,14 @@ public class ItensVendidos
 
     public void setQuantidadeEspecifica(float quantidadeEspecifica) { this.quantidadeEspecifica = quantidadeEspecifica; }
 
+    public float getPeso() { return peso; }
+
+    public void setPeso(float peso) { this.peso = peso; }
+
+    public float getContribuicao() { return contribuicao; }
+
+    public void setContribuicao(float contribuicao) { this.contribuicao = contribuicao; }
+
     @Override
     public String toString()
     {
@@ -127,12 +138,18 @@ public class ItensVendidos
             builder.append(ms.comEsquerda(complemento, " ", 15));
         }
         catch (Exception e) { /*****/ }
-
-        builder.append("\nV.:");
+        //TODO: Verificar a razão de o valor digitado ser igual ao valor digitado
+        /*
+        builder.append("  VT.:");
+        builder.append(ms.comEsquerda(Formatacao.format2d(valorTabela), " ", 8));
+        */
+        builder.append("\nVB.:");
         builder.append(ms.comEsquerda(Formatacao.format2d(valorDigitado), " ", 8));
-        builder.append("  Q.:");
+        builder.append("  VL.:");
+        builder.append(ms.comEsquerda(Formatacao.format2d(valorLiquido), " ", 8));
+        builder.append("  QD.:");
         builder.append(ms.comEsquerda(Formatacao.format2d(quantidade), " ", 8));
-        builder.append("  T.:");
+        builder.append("  TL.:");
         builder.append(ms.comEsquerda(Formatacao.format2d(total), " ", 8));
 
         return /*item +*/ builder.toString();

--- a/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/modelo/Venda.java
+++ b/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/modelo/Venda.java
@@ -29,6 +29,10 @@ public class Venda
     private int enviado;
     private int justificativa;
 
+    private int volume;
+    private int contribuicao;
+
+
     public Venda() { this.itens = new ArrayList<>(); }
 
     public Integer getCodigo() { return codigo; }
@@ -102,6 +106,14 @@ public class Venda
     public int getJustificativa() { return justificativa; }
 
     public void setJustificativa(int justificativa) { this.justificativa = justificativa; }
+
+    public int getVolume() { return volume; }
+
+    public void setVolume(int volume) { this.volume = volume; }
+
+    public int getContribuicao() { return contribuicao; }
+
+    public void setContribuicao(int contribuicao) { this.contribuicao = contribuicao; }
 
     @Override
     public String toString()

--- a/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/persistencia/queries/CampanhaProdutoDataAccess.java
+++ b/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/persistencia/queries/CampanhaProdutoDataAccess.java
@@ -155,9 +155,22 @@ public class CampanhaProdutoDataAccess
                 this.sBuilder.append("SELECT ");
                 this.sBuilder.append(
                         br.com.sulpasso.sulpassomobile.persistencia.tabelas.CampanhaProduto.ITEM);
+                this.sBuilder.append(", ");
+                this.sBuilder.append(
+                        br.com.sulpasso.sulpassomobile.persistencia.tabelas.Item.DESCRICAO);
                 this.sBuilder.append(" FROM ");
                 this.sBuilder.append(
                         br.com.sulpasso.sulpassomobile.persistencia.tabelas.CampanhaProduto.TABELA);
+
+                this.sBuilder.append(" JOIN ");
+                this.sBuilder.append(
+                        br.com.sulpasso.sulpassomobile.persistencia.tabelas.Item.TABELA);
+                this.sBuilder.append(" ON ");
+                this.sBuilder.append(
+                        br.com.sulpasso.sulpassomobile.persistencia.tabelas.Item.CODIGO);
+                this.sBuilder.append(" = ");
+                this.sBuilder.append(
+                        br.com.sulpasso.sulpassomobile.persistencia.tabelas.CampanhaProduto.ITEM);
                 this.sBuilder.append(" WHERE ");
                 this.sBuilder.append(
                         br.com.sulpasso.sulpassomobile.persistencia.tabelas.CampanhaProduto.CODIGO);
@@ -168,15 +181,19 @@ public class CampanhaProdutoDataAccess
                 c.moveToFirst();
 
                 ArrayList<Integer> item = new ArrayList<>();
+                ArrayList<String> itemDesc = new ArrayList<>();
                 for(int d = 0; d < c.getCount(); d++)
                 {
                     item.add(new Integer(c.getInt(c.getColumnIndex(
                             br.com.sulpasso.sulpassomobile.persistencia.tabelas.CampanhaProduto.ITEM))));
+                    itemDesc.add(c.getString(c.getColumnIndex(
+                            br.com.sulpasso.sulpassomobile.persistencia.tabelas.Item.DESCRICAO)));
 
                     c.moveToNext();
                 }
 
                 ((CampanhaProduto) lista.get(i)).setItens(item);
+                ((CampanhaProduto) lista.get(i)).setItensDesc(itemDesc);
             }
         }
         catch (Exception e) { throw new ReadExeption("Possível falta de memória no aparelho."); }

--- a/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/persistencia/queries/CorteDataAccess.java
+++ b/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/persistencia/queries/CorteDataAccess.java
@@ -253,6 +253,12 @@ public class CorteDataAccess
 
             item.setItem(c.getInt(c.getColumnIndex(
                 br.com.sulpasso.sulpassomobile.persistencia.tabelas.Corte.PRODUTO)));
+            item.setReferencia(c.getString(c.getColumnIndex((
+                br.com.sulpasso.sulpassomobile.persistencia.tabelas.Item.REFERENCIA))));
+            item.setDescricao(c.getString(c.getColumnIndex((
+                    br.com.sulpasso.sulpassomobile.persistencia.tabelas.Item.DESCRICAO))));
+            item.setComplemento(c.getString(c.getColumnIndex((
+                    br.com.sulpasso.sulpassomobile.persistencia.tabelas.Item.COMPLEMENTO))));
             item.setQuantidade(c.getFloat(c.getColumnIndex(
                 br.com.sulpasso.sulpassomobile.persistencia.tabelas.Corte.QUANTIDADE)));
 

--- a/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/persistencia/queries/ItemDataAccess.java
+++ b/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/persistencia/queries/ItemDataAccess.java
@@ -13,6 +13,7 @@ import br.com.sulpasso.sulpassomobile.exeption.InsertionExeption;
 import br.com.sulpasso.sulpassomobile.exeption.ReadExeption;
 import br.com.sulpasso.sulpassomobile.modelo.Foco;
 import br.com.sulpasso.sulpassomobile.modelo.Gravosos;
+import br.com.sulpasso.sulpassomobile.modelo.Grupo;
 import br.com.sulpasso.sulpassomobile.modelo.Item;
 import br.com.sulpasso.sulpassomobile.persistencia.database.SimplySalePersistencySingleton;
 import br.com.sulpasso.sulpassomobile.util.Enumarations.TiposBuscaItens;
@@ -1099,6 +1100,13 @@ public class ItemDataAccess
                         c.getFloat(c.getColumnIndex(
                                 br.com.sulpasso.sulpassomobile.persistencia.tabelas.Item.FAIXA)));
 
+                item.setPeso(
+                        c.getFloat(c.getColumnIndex(
+                                br.com.sulpasso.sulpassomobile.persistencia.tabelas.Item.PESO)));
+                item.setPesoCd(
+                        c.getFloat(c.getColumnIndex(
+                                br.com.sulpasso.sulpassomobile.persistencia.tabelas.Item.PESOCD)));
+
                 item.setContribuicao(
                         c.getFloat(c.getColumnIndex(
                                 br.com.sulpasso.sulpassomobile.persistencia.tabelas.Item.CONTRIBUICAO)));
@@ -1440,6 +1448,17 @@ public class ItemDataAccess
 
                 String des = c.getString(c.getColumnIndex(
                         br.com.sulpasso.sulpassomobile.persistencia.tabelas.Item.DESTAQUE));
+
+                item.setFaixa(
+                        c.getFloat(c.getColumnIndex(
+                                br.com.sulpasso.sulpassomobile.persistencia.tabelas.Item.FAIXA)));
+
+                item.setPeso(
+                        c.getFloat(c.getColumnIndex(
+                                br.com.sulpasso.sulpassomobile.persistencia.tabelas.Item.PESO)));
+                item.setPesoCd(
+                        c.getFloat(c.getColumnIndex(
+                                br.com.sulpasso.sulpassomobile.persistencia.tabelas.Item.PESOCD)));
 
                 int destaque = Integer.parseInt(des);
 
@@ -1878,6 +1897,15 @@ public class ItemDataAccess
                 item.setQuantidadeCaixa(
                         c.getInt(c.getColumnIndex(
                                 br.com.sulpasso.sulpassomobile.persistencia.tabelas.Item.QUANTIDADECAIXA)));
+                item.setFaixa(
+                        c.getFloat(c.getColumnIndex(
+                                br.com.sulpasso.sulpassomobile.persistencia.tabelas.Item.FAIXA)));
+                item.setPeso(
+                        c.getFloat(c.getColumnIndex(
+                                br.com.sulpasso.sulpassomobile.persistencia.tabelas.Item.PESO)));
+                item.setPesoCd(
+                        c.getFloat(c.getColumnIndex(
+                                br.com.sulpasso.sulpassomobile.persistencia.tabelas.Item.PESOCD)));
 
                 item.setContribuicao(
                         c.getFloat(c.getColumnIndex(
@@ -2665,5 +2693,113 @@ public class ItemDataAccess
         return valor;
         */
         return 0;
+    }
+
+    public Grupo getGrupoItem(int item)
+    {
+        this.sBuilder.delete(0, this.sBuilder.length());
+        this.sBuilder.append("SELECT ");
+        this.sBuilder.append(
+                br.com.sulpasso.sulpassomobile.persistencia.tabelas.Item.GRUPO);
+        this.sBuilder.append(", ");
+        this.sBuilder.append(
+                br.com.sulpasso.sulpassomobile.persistencia.tabelas.Item.SUBGRUPO);
+        this.sBuilder.append(", ");
+        this.sBuilder.append(
+                br.com.sulpasso.sulpassomobile.persistencia.tabelas.Item.DIVISAO);
+        this.sBuilder.append(" FROM ");
+        this.sBuilder.append(
+                br.com.sulpasso.sulpassomobile.persistencia.tabelas.Item.TABELA);
+        this.sBuilder.append(" WHERE ");
+        this.sBuilder.append(
+                br.com.sulpasso.sulpassomobile.persistencia.tabelas.Item.CODIGO);
+        this.sBuilder.append(" = ");
+        this.sBuilder.append(item);
+
+        Cursor c = this.db.rawQuery(this.sBuilder.toString(), null);
+
+        c.moveToFirst();
+
+        Grupo g = new Grupo();
+
+        try
+        {
+            g.setGrupo(c.getInt(0));
+            g.setSubGrupo(c.getInt(1));
+            g.setDivisao(c.getInt(2));
+        }
+        catch (Exception e)
+        {
+            g = null;
+        }
+
+        c.close();
+        SQLiteDatabase.releaseMemory();
+        return g;
+    }
+
+    public boolean vendaKilo(int item) {
+        boolean vendaKilo = false;
+
+        this.sBuilder.delete(0, this.sBuilder.length());
+        this.sBuilder.append("SELECT ");
+        this.sBuilder.append(
+                br.com.sulpasso.sulpassomobile.persistencia.tabelas.Item.UNIDADEVENDA);
+        this.sBuilder.append(", ");
+        this.sBuilder.append(
+                br.com.sulpasso.sulpassomobile.persistencia.tabelas.Item.UNIDADE);
+        this.sBuilder.append(" FROM ");
+        this.sBuilder.append(
+                br.com.sulpasso.sulpassomobile.persistencia.tabelas.Item.TABELA);
+        this.sBuilder.append(" WHERE ");
+        this.sBuilder.append(
+                br.com.sulpasso.sulpassomobile.persistencia.tabelas.Item.CODIGO);
+        this.sBuilder.append(" = ");
+        this.sBuilder.append(item);
+
+        Cursor c = this.db.rawQuery(this.sBuilder.toString(), null);
+
+        c.moveToFirst();
+
+        try { vendaKilo = c.getString(1).equals("KG") && !c.getString(0).equals("KG"); }
+        catch (Exception e) { vendaKilo = false; }
+        finally
+        {
+            c.close();
+            SQLiteDatabase.releaseMemory();
+        }
+
+        return vendaKilo;
+    }
+
+    public float getFaixa(int item) {
+        float faixa = 1;
+
+        this.sBuilder.delete(0, this.sBuilder.length());
+        this.sBuilder.append("SELECT ");
+        this.sBuilder.append(
+                br.com.sulpasso.sulpassomobile.persistencia.tabelas.Item.FAIXA);
+        this.sBuilder.append(" FROM ");
+        this.sBuilder.append(
+                br.com.sulpasso.sulpassomobile.persistencia.tabelas.Item.TABELA);
+        this.sBuilder.append(" WHERE ");
+        this.sBuilder.append(
+                br.com.sulpasso.sulpassomobile.persistencia.tabelas.Item.CODIGO);
+        this.sBuilder.append(" = ");
+        this.sBuilder.append(item);
+
+        Cursor c = this.db.rawQuery(this.sBuilder.toString(), null);
+
+        c.moveToFirst();
+
+        try { faixa = c.getFloat(0) > 0 ? c.getFloat(0) : 1; }
+        catch (Exception e) { faixa = 1; }
+        finally
+        {
+            c.close();
+            SQLiteDatabase.releaseMemory();
+        }
+
+        return faixa;
     }
 }

--- a/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/persistencia/queries/VendaDataAccess.java
+++ b/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/persistencia/queries/VendaDataAccess.java
@@ -1557,6 +1557,9 @@ public class VendaDataAccess
             {
                 ItensVendidos item = new ItensVendidos();
 
+                item.setDescontoCG(0);
+                item.setDescontoCP(0);
+
                 item.setItem(
                         c.getInt(c.getColumnIndex(
                                 br.com.sulpasso.sulpassomobile.persistencia.tabelas.ItensVendidos.ITEM)));
@@ -1576,11 +1579,18 @@ public class VendaDataAccess
                         c.getFloat(c.getColumnIndex(
                                 br.com.sulpasso.sulpassomobile.persistencia.tabelas.ItensVendidos.VALORDIGITADO)));
 
+                item.setDescontoCP(
+                        c.getFloat(c.getColumnIndex(
+                                br.com.sulpasso.sulpassomobile.persistencia.tabelas.ItensVendidos.DESCONTOCP)));
+                item.setDescontoCG(
+                        c.getFloat(c.getColumnIndex(
+                                br.com.sulpasso.sulpassomobile.persistencia.tabelas.ItensVendidos.DESCONTOCG)));
+
+                item.setDescontoCampanha((item.getDescontoCG() > 0 || item.getDescontoCP() > 0));
 
                 item.setDescricao(c.getString(c.getColumnIndex("id")));
                 item.setReferencia(c.getString(c.getColumnIndex("ir")));
                 item.setComplemento(c.getString(c.getColumnIndex("ic")));
-
 
                 itens.add(item);
                 c.moveToNext();

--- a/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/persistencia/tabelas/Venda.java
+++ b/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/persistencia/tabelas/Venda.java
@@ -25,6 +25,9 @@ public class Venda
     public static final String NATUREZA = "PedidosNatureza";
     public static final String EXCLUIDO = "PedidoValido";
 
+    public static final String VOLUME = "PedidosVolume";
+    public static final String CONTRIBUICAO = "PedidoContribuicao";
+
     public static String CriarTabela()
     {
         String stmt;
@@ -92,10 +95,26 @@ public class Venda
         String stmt;
         StringBuilder builder = new StringBuilder();
 
+        /*
         builder.append("ALTER TABLE ");
         builder.append(TABELA);
         builder.append(" ADD COLUMN ");
         builder.append(EXCLUIDO);
+        builder.append(Types.FLOAT);
+        builder.append(" DEFAULT 0;");
+        */
+
+
+        builder.append("ALTER TABLE ");
+        builder.append(TABELA);
+        builder.append(" ADD COLUMN ");
+        builder.append(VOLUME);
+        builder.append(Types.FLOAT);
+        builder.append(" DEFAULT 0;");
+        builder.append("ALTER TABLE ");
+        builder.append(TABELA);
+        builder.append(" ADD COLUMN ");
+        builder.append(CONTRIBUICAO);
         builder.append(Types.FLOAT);
         builder.append(" DEFAULT 0;");
 

--- a/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/util/funcoes/ManipulacaoStrings.java
+++ b/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/util/funcoes/ManipulacaoStrings.java
@@ -18,6 +18,17 @@ public class ManipulacaoStrings
         return (s + resp).substring(0, n);
     }
 
+    public String comDireita2(String value, String caracter, int n)
+    {
+        String s = value.trim();
+        StringBuffer resp = new StringBuffer();
+
+        for (int x = 0; x < n; x++)
+            resp.append(caracter);
+
+        return (s + resp);
+    }
+
     public String comEsquerda(String value, String caracter, int n)
     {
         String s = value.trim();
@@ -88,7 +99,7 @@ public class ManipulacaoStrings
 
     private boolean isSpecialCharacter(int b)
     {
-        if(b == 32 )
+        if(b == 32 || b == 44 || b == 46 )
         {
                 return false;
         }

--- a/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/util/funcoes/ManipularArquivos.java
+++ b/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/util/funcoes/ManipularArquivos.java
@@ -142,6 +142,19 @@ public class ManipularArquivos
             f = new File(Environment.getExternalStorageDirectory() + "/MobileVenda/", this.nomeArquivo);
         }
         */
+        if(this.nomeArquivo == null || this.nomeArquivo.isEmpty())
+        {
+            ConfiguradorDataAccess cda = new ConfiguradorDataAccess(this.context);
+            int sequencia;
+            int usuario;
+            ManipulacaoStrings ms = new ManipulacaoStrings();
+
+            sequencia = cda.buscarSequencias(0);
+            usuario = cda.buscarCodigoUsuario();
+
+            this.nomeArquivo = "Pw" + ms.comEsquerda("" + usuario, "0", 4) + "." + ms.comEsquerda("" + (sequencia + 1), "0", 3);
+        }
+
         f = new File(Environment.getExternalStorageDirectory() + "/MobileVenda/", this.nomeArquivo);
 
         return (f);

--- a/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/util/funcoes/SenhaLiberacao.java
+++ b/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/util/funcoes/SenhaLiberacao.java
@@ -9,7 +9,9 @@ public class SenhaLiberacao
 {
     private String chave;
     private String str_chave_valor;
-    private final int NUMERO = 91026;
+    private String str_chave_valorNew;
+    //private final int NUMERO = 91026;
+    private final int NUMERO = 17842;
     private int tipo;
 
     private ManipulacaoStrings ms;
@@ -19,6 +21,14 @@ public class SenhaLiberacao
     int month;
     int sun;
     String pswd;
+
+
+    String strQtd;
+    String strVal;
+    String strMsQV;
+    String strMsch;
+
+
 
     /**
      * Calcula randomicamente a chave de acesso para a senha quando não é utilizado valor
@@ -80,15 +90,24 @@ public class SenhaLiberacao
 
         String str_valor;
         String str_qtd;
-        this.chave = "" + (1 + (int) (Math.random()*1000));
-        String str_chave = "" + mascaraChave(Integer.parseInt(this.chave));
+        String str_qtdV;
+        this.chave = "" + (101 + (int) (Math.random() * 10000));
+        //String str_chave = "" + mascaraChave(Integer.parseInt(this.chave));
+        String str_chave = "" + calculaChave(Integer.parseInt(this.chave));
 
         str_valor = Formatacao.format3(valor, 2).replace(".", "").replace(",", "");
         str_qtd = Formatacao.format3(quantidade, 2).replace(".", "").replace(",", "");
 
-        str_qtd = "" + mascaraQuantidade(str_qtd, str_valor);
+        this.strQtd = str_qtd;
+        this.strVal = str_valor;
 
-        this.str_chave_valor = mascaraChave(str_chave, str_qtd);
+        str_qtdV = "" + mascaraValores(str_valor, str_qtd);
+
+        strMsQV = str_qtd;
+
+        this.str_chave_valor = mascaraValores(str_qtdV, str_chave);
+
+        strMsch = str_chave;
 
         this.tipo = 2;
     }
@@ -98,7 +117,12 @@ public class SenhaLiberacao
      */
     public String getChave()
     {
-        if (tipo == 1 || tipo == 2) return str_chave_valor;
+        if (tipo == 1 || tipo == 2) return str_chave_valor; /*+
+                "\nQ" + this.strQtd+ " - V " +
+        this.strVal+ " - QV " +
+        this.strMsQV+ " - " +
+        this.strMsch + " - MCH" +
+               "\n" +  chave;*/
         else return chave;
     }
 
@@ -140,6 +164,24 @@ public class SenhaLiberacao
      */
     public Boolean verificaChavePedido(String senha)
     {
+        /*
+        int constMult = 9;
+        int sun = 0;
+        int sti = 0;
+        for(int i = 0; i < this.str_chave_valor.length(); i++)
+        {
+            if (constMult < 1)
+                constMult = 9;
+
+            sti = Integer.parseInt(this.str_chave_valor.substring(i, i + 1));
+            sun += sti * constMult--;
+        }
+
+        int rest = sun % 11;
+        rest = rest * 11;
+        sun = sun - rest;
+
+
         day = cal.get(Calendar.DAY_OF_MONTH);
         sun = (Integer.parseInt(chave) * day);
 
@@ -149,6 +191,9 @@ public class SenhaLiberacao
             return true;
 
         return false;
+        */
+
+        return this.chave.equals(senha);
     }
 
     /**
@@ -175,26 +220,19 @@ public class SenhaLiberacao
     private String mascaraQuantidade(String quantidade, String valor)
     {
         StringBuilder nq = new StringBuilder();
-        int dif = valor.length() > quantidade.length() ? valor.length() - quantidade.length() :
-                quantidade.length() - valor.length();
 
-        int i = 0;
-
-        for (i = 0; i < valor.length(); i++)
+        if(valor.length() > quantidade.length())
         {
-            nq.append(valor.substring(i, i+1));
-
-            if (i < quantidade.length()){ nq.append(quantidade.substring(i, i+1)); }
-        }
-
-        if (i < quantidade.length())
-        {
-            nq.append(quantidade.substring(i));
+            ms.comEsquerda(quantidade, "0", valor.length());
+            nq.append(misturar(valor, quantidade, false));
             nq.append("1");
         }
-        else { nq.append("0"); }
-
-        nq.append("" + dif);
+        else
+        {
+            ms.comEsquerda(valor, "0", quantidade.length());
+            nq.append(misturar(quantidade, valor, false));
+            nq.append("2");
+        }
 
         return nq.toString();
     }
@@ -208,7 +246,7 @@ public class SenhaLiberacao
     {
         day = cal.get(Calendar.DAY_OF_MONTH);
 
-        sun = (chave * day);
+        sun = (chave * day) + NUMERO;
 
         return sun;
     }
@@ -221,25 +259,86 @@ public class SenhaLiberacao
     private String mascaraChave(String chave, String valor)
     {
         StringBuilder nq = new StringBuilder();
-        int dif = valor.length() > chave.length() ? valor.length() - chave.length() : chave.length() - valor.length();
-        int i = 0;
 
-        for (i = 0; i < valor.length(); i++)
+        if(valor.length() > chave.length())
         {
-            nq.append(valor.substring(i, i+1));
-
-            if (i < chave.length()){ nq.append(chave.substring(i, i+1)); }
-        }
-
-        if (i < chave.length())
-        {
-            nq.append(chave.substring(i));
+            ms.comEsquerda(chave, "0", valor.length());
+            nq.append(misturar(valor, chave, false));
             nq.append("1");
         }
-        else { nq.append("0"); }
-
-        nq.append("" + dif);
+        else
+        {
+            ms.comEsquerda(valor, "0", chave.length());
+            nq.append(misturar(chave, valor, false));
+            nq.append("2");
+        }
 
         return nq.toString();
     }
+
+    /**
+     * Calculo para mascarar a chave
+     *
+     * @return
+     */
+    private int calculaChave(int chave)
+    {
+        day = cal.get(Calendar.DAY_OF_MONTH);
+
+        sun = (chave * day) + NUMERO;
+
+        return sun;
+    }
+
+    /**
+     * Calculo para misturar duas strings via de regra, o primeiro item é sempre valor
+     *
+     * @param str1
+     * @param str2
+     * @return
+     */
+    private String mascaraValores(String str1, String str2)
+    {
+        StringBuilder nq = new StringBuilder();
+
+        if(str1.length() > str2.length())
+        {
+            str2 = ms.comEsquerda(str2, "0", str1.length());
+            nq.append(misturar(str1, str2, false));
+            nq.append("1");
+        }
+        else
+        {
+            str1 = ms.comEsquerda(str1, "0", str2.length());
+            nq.append(misturar(str2, str1, false));
+            nq.append("2");
+        }
+
+        return nq.toString();
+    }
+
+    /**
+     *
+     * @param str1
+     * @param str2
+     * @return
+     */
+    private String misturar(String str1, String str2, boolean reverse)
+    {
+        StringBuilder nq = new StringBuilder();
+        int i = 0;
+
+        for (i = 0; i < str1.length(); i++)
+        {
+            nq.append(str1.substring(i, i+1));
+
+            if(!reverse)
+                nq.append(str2.substring(i, i+1));
+            else
+                nq.append(str2.substring(str2.length() - i + 1, str2.length() - i));
+        }
+
+        return nq.toString();
+    }
+
 }

--- a/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/views/Pedido.java
+++ b/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/views/Pedido.java
@@ -60,6 +60,10 @@ public class Pedido extends AppCompatActivity
     private String senha;
 
     private Boolean pesquisar;
+
+    private int quantidadeRemovida;
+
+    private boolean firstTimeIn = true;
 /**********************************ACTIVITY LIFE CICLE*********************************************/
     @Override
     protected void onCreate(Bundle savedInstanceState)
@@ -136,6 +140,8 @@ public class Pedido extends AppCompatActivity
         gestureDetector = new GestureDetector(this, android_gesture_detector);
 
         pesquisar = true;
+
+        quantidadeRemovida = 0;
     }
 
     @Override
@@ -405,7 +411,13 @@ public class Pedido extends AppCompatActivity
         {
             fragment = (DadosClienteFragment) fragmentManager.findFragmentById(R.id.frame_container);
 
-            if (fragment != null) { fragment.ajustarLayout(); }
+            if (fragment != null)
+            {
+                if(this.controlePedido.getClass() == Troca.class)
+                    fragment.ajustarLayout2();
+                else
+                    fragment.ajustarLayout();
+            }
         }
         catch (Exception e)
         {
@@ -499,9 +511,14 @@ public class Pedido extends AppCompatActivity
 
     public void recalcularPrecos()
     {
-        this.controlePedido.recalcularValor();
+        boolean alterar = this.controlePedido.recalcularValor(!firstTimeIn);
         this.exibirTotalPedido();
-        Toast.makeText(getApplicationContext(), "Preços recalculados", Toast.LENGTH_LONG).show();
+
+        if (alterar)
+            Toast.makeText(getApplicationContext(), "Preços recalculados", Toast.LENGTH_LONG).show();
+
+
+        firstTimeIn = false;
     }
 
     public int itensVendidos() { return this.controlePedido.itensVendidos(); }
@@ -601,6 +618,8 @@ public class Pedido extends AppCompatActivity
 
     public void selecionarItem(int position)
     {
+        this.controlePedido.setQuantidadeRemover(this.controlePedido.quantidadeItem(position));
+
         this.controlePedido.selecionarItem(position);
         displayView(2);
     }
@@ -794,7 +813,11 @@ public class Pedido extends AppCompatActivity
 
     public void verificarEncerramento(int p)
     {
-        if(p == 2) { this.displayView(1); }
+        if(p == 2)
+        {
+
+            this.displayView(1);
+        }
         else
         {
             String titulo = "ATENÇÃO -- CANCELAMENTO";
@@ -987,6 +1010,8 @@ public class Pedido extends AppCompatActivity
 //        update the main content by replacing fragments
         String title = getString(R.string.telaPedido);
         Fragment fragment = null;
+
+        firstTimeIn = true;
 
         switch (position)
         {
@@ -1263,8 +1288,11 @@ public class Pedido extends AppCompatActivity
 
                                 String[] itens = item.split(" - ");
 
-                                if(itens[1].indexOf(filter) == 0)
-                                    cidadesFiltered.add(cidades.get(i));
+                                if(itens.length > 1)
+                                {
+                                    if(itens[1].indexOf(filter) == 0)
+                                        cidadesFiltered.add(cidades.get(i));
+                                }
                                 /*
                                 item = cidades.get(i);
 
@@ -1358,10 +1386,10 @@ public class Pedido extends AppCompatActivity
             }
         });
 
-        if(tipo == 3)
+//        if(tipo == 3)
             alert.setView(ll);
-        else
-            alert.setView(input);
+//        else
+//            alert.setView(input);
 
         alert.show();
     }

--- a/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/views/fragments/DadosClienteFragment.java
+++ b/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/views/fragments/DadosClienteFragment.java
@@ -269,6 +269,79 @@ public class DadosClienteFragment extends Fragment implements AlertDetalhesClien
 
         ((getActivity().findViewById(R.id.fdcBtnDetalhes))).setVisibility(View.VISIBLE);
     }
+    public void ajustarLayout2()
+    {
+        ESPECIAL = activity.buscarDadosCliente(R.id.fdcTxtStatus).substring(0, 1).equalsIgnoreCase("E");
+
+        ArrayAdapter adapter = new ArrayAdapter(
+                getActivity().getApplicationContext(), R.layout.spinner_item, activity.listarNaturezas(ESPECIAL));
+        adapter.setDropDownViewResource(R.layout.spinner_dropdown_item);
+        this.fdcSpnrNaturezas.setAdapter(adapter);
+
+        if(activity.controlaRoteiro())
+        {
+            this.fdcSpnrMotivos.setOnItemSelectedListener(justificando);
+            activity.listarMotivos();
+            this.fdcSpnrMotivos.setVisibility(View.GONE);
+        }
+
+        if(this.activity.verificarTitulos())
+        {
+            AlertCortesDevolucaoTitulos dialog = new AlertCortesDevolucaoTitulos();
+            dialog.setTargetFragment(this, 1); //request code
+            dialog.show(getFragmentManager(), "DIALOG");
+        }
+
+        if(this.activity.verificarDevolucoes())
+        {
+            AlertCortesDevolucaoTitulos dialog = new AlertCortesDevolucaoTitulos();
+            dialog.setTargetFragment(this, 1); //request code
+            dialog.show(getFragmentManager(), "DIALOG");
+        }
+
+        /*
+        this.fdcSpnrNaturezas.setAdapter(
+            new ArrayAdapter<String>(getActivity().getApplicationContext(),
+                android.support.design.R.layout.support_simple_spinner_dropdown_item,
+                activity.listarNaturezas(!ESPECIAL)));
+        */
+
+        this.fdcSpnrNaturezas.setSelection(this.activity.buscarNatureza());
+
+        this.fdcSpnrNaturezas.setOnItemSelectedListener(selectingData);
+
+        this.fdcSpnrNaturezas.setClickable(this.activity.permitirClick(R.id.fdcSpnrNaturezas));
+        this.fdcSpnrNaturezas.setEnabled(this.activity.permitirClick(R.id.fdcSpnrNaturezas));
+        this.fdcSpnrPrazos.setClickable(this.activity.permitirClick(R.id.fdcSpnrPrazos));
+        this.fdcSpnrPrazos.setEnabled(this.activity.permitirClick(R.id.fdcSpnrPrazos));
+
+        ((EditText) (getActivity().findViewById(R.id.fdcEdtCidade)))
+                .setText(activity.buscarDadosCliente(R.id.fdcEdtCidade));
+        ((EditText) (getActivity().findViewById(R.id.fdcEdtUf)))
+                .setText(activity.buscarDadosCliente(R.id.fdcEdtUf));
+        ((EditText) (getActivity().findViewById(R.id.fdcEdtEnd)))
+                .setText(activity.buscarDadosCliente(R.id.fdcEdtEnd));
+        ((EditText) (getActivity().findViewById(R.id.fdcEdtFone)))
+                .setText(activity.buscarDadosCliente(R.id.fdcEdtFone));
+        ((EditText) (getActivity().findViewById(R.id.fdcEdtCel)))
+                .setText(activity.buscarDadosCliente(R.id.fdcEdtCel));
+        ((EditText) (getActivity().findViewById(R.id.fdcEdtUltima)))
+                .setText(activity.buscarDadosCliente(R.id.fdcEdtUltima));
+        ((EditText) (getActivity().findViewById(R.id.fdcEdtMeta)))
+                .setText(activity.buscarDadosCliente(R.id.fdcEdtMeta));
+        ((EditText) (getActivity().findViewById(R.id.fdcEdtReal)))
+                .setText(activity.buscarDadosCliente(R.id.fdcEdtReal));
+        ((EditText) (getActivity().findViewById(R.id.fdcEdtLimite)))
+                .setText(activity.buscarDadosCliente(R.id.fdcEdtLimite));
+        ((EditText) (getActivity().findViewById(R.id.fdcEdtQuantidade)))
+                .setText(activity.buscarDadosCliente(R.id.fdcEdtQuantidade));
+        ((EditText) (getActivity().findViewById(R.id.fdcEdtMedia)))
+                .setText(activity.buscarDadosCliente(R.id.fdcEdtMedia));
+        ((EditText) (getActivity().findViewById(R.id.fdcEdtDca)))
+                .setText(activity.buscarDadosVenda(R.id.fdcEdtDca));
+
+        ((getActivity().findViewById(R.id.fdcBtnDetalhes))).setVisibility(View.VISIBLE);
+    }
 
     public void ajustarPrazos(int posicao)
     {
@@ -586,8 +659,11 @@ public class DadosClienteFragment extends Fragment implements AlertDetalhesClien
 
             String[] itens = item.split(" - ");
 
-            if(itens[1].indexOf(pattern) == 0)
-                this.source.add(this.full.get(i));
+            if(itens.length > 1)
+            {
+                if(itens[1].indexOf(pattern) == 0)
+                    this.source.add(this.full.get(i));
+            }
             /*
             item = this.full.get(i);
 

--- a/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/views/fragments/DigitacaoItemFragment.java
+++ b/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/views/fragments/DigitacaoItemFragment.java
@@ -18,6 +18,7 @@ import android.widget.TextView;
 import java.util.ArrayList;
 
 import br.com.sulpasso.sulpassomobile.R;
+import br.com.sulpasso.sulpassomobile.util.funcoes.ManipulacaoStrings;
 import br.com.sulpasso.sulpassomobile.views.Pedido;
 import br.com.sulpasso.sulpassomobile.views.fragments.alertas.AlertaPromocoes;
 
@@ -244,6 +245,20 @@ public class DigitacaoItemFragment extends Fragment implements AlertaPromocoes.E
         ((EditText) (getActivity().findViewById(R.id.fdEdtMkp))).setOnFocusChangeListener(alteracaoFoco);
 
         ((EditText) (getActivity().findViewById(R.id.fdEdtQuantidade))).requestFocus();
+
+        ((EditText) (getActivity().findViewById(R.id.fdEdtValor))).setOnFocusChangeListener(new View.OnFocusChangeListener() {
+            @Override
+            public void onFocusChange(View view, boolean b) {
+                String val = ((EditText)(getActivity().findViewById(R.id.fdEdtValor))).getText().toString();
+
+                if(val.indexOf('.') != -1 && (val.substring(val.indexOf('.'))).length() < 3)
+                {
+                    ManipulacaoStrings ms = new ManipulacaoStrings();
+                    ((EditText) (getActivity().findViewById(R.id.fdEdtValor)))
+                            .setText(ms.comDireita2(val, "0", 3 - (val.substring(val.indexOf('.'))).length()));
+                }
+            }
+        });
     }
 
     private void exibirTotal()


### PR DESCRIPTION
Acrescentar peso na tela de resumo do pedido.
Acrescentar valor liquido ao item no resumo do pedido.
Consulta de campanhas pro produto precisa trazer a descrição do item.
Verificar inserção de item com campanha
Acrescentar contribuição ao resumo do pedido.
Erro na busca de clientes por razão social ou nome fantasia.
Erro na consulta de cortes

(ITENS QUE SE INTERPUSERAM NO CAMINHO DA SPRINT)
Senha de Desconto
Controle Liberação Senha
Alteração no campo mensagem CPD