### PR TITLE
Alteração tipos destaques

### DIFF
--- a/SulpassoMobile/app/build.gradle
+++ b/SulpassoMobile/app/build.gradle
@@ -9,7 +9,7 @@ android{
         minSdkVersion 16
         targetSdkVersion 28
         versionCode 952
-        versionName "3.003.0018"
+        versionName "3.003.0019"
     }
     buildTypes {
         release {

--- a/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/controle/Adapters/AdapterItensPedido.java
+++ b/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/controle/Adapters/AdapterItensPedido.java
@@ -58,15 +58,30 @@ public class AdapterItensPedido extends BaseAdapter
         }
         else { holder = (ViewHolder) convertView.getTag(); }
 
-        if(mensagem.getSold())
-            convertView.setBackgroundResource(R.color.LightGreen);
-        else
-            convertView.setBackgroundResource(R.color.bgColor);
-
         if(mensagem.getItem().isDestaque())
             holder.separador.setBackgroundResource(R.color.LightGreen);
         else
             holder.separador.setBackgroundResource(R.color.bgColor);
+
+
+        if(mensagem.getItem().getDestaqueTipo() == 1)
+            holder.separador.setBackgroundResource(R.color.LightSkyBlue);
+        else if(mensagem.getItem().getDestaqueTipo() == 2)
+            holder.separador.setBackgroundResource(R.color.DarkSlateBlue);
+
+
+
+
+        if(mensagem.getSold())
+            convertView.setBackgroundResource(R.color.LightGreen);
+        else
+            if(mensagem.getItem().getDestaqueTipo() == 1)
+                convertView.setBackgroundResource(R.color.LightSkyBlue);
+            else if(mensagem.getItem().getDestaqueTipo() == 2)
+                convertView.setBackgroundResource(R.color.DarkSlateBlue);
+            else
+                convertView.setBackgroundResource(R.color.bgColor);
+
 
         holder.codigo.setText(String.valueOf(mensagem.getItem().getCodigo()));
         holder.referencia.setText(mensagem.getItem().getReferencia());

--- a/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/modelo/Item.java
+++ b/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/modelo/Item.java
@@ -36,6 +36,8 @@ public class Item
 
     private boolean destaque;
 
+    private int destaqueTipo;
+
     private float vt;
 
     public float getVt() { return vt; }
@@ -134,6 +136,10 @@ public class Item
 
     public void setDestaque(boolean destaque) { this.destaque = destaque; }
 
+    public int getDestaqueTipo() { return destaqueTipo; }
+
+    public void setDestaqueTipo(int destaqueTipo) { this.destaqueTipo = destaqueTipo; }
+
     @Override
     public String toString() {
         return "Item{" +
@@ -159,6 +165,7 @@ public class Item
                 ", tvd='" + tvd + '\'' +
                 ", estoque=" + estoque +
                 ", aplicacao='" + aplicacao + '\'' +
+                ", foco=" + destaqueTipo  +
                 '}';
     }
 

--- a/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/persistencia/queries/ItemDataAccess.java
+++ b/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/persistencia/queries/ItemDataAccess.java
@@ -327,7 +327,8 @@ public class ItemDataAccess
         this.sBuilder.append("', '");
         this.sBuilder.append(item.getCusto());
         this.sBuilder.append("', '");
-        this.sBuilder.append((item.isDestaque() ? "9" : "0"));
+        //this.sBuilder.append((item.isDestaque() ? "9" : "0"));
+        this.sBuilder.append((item.getDestaqueTipo()));
         this.sBuilder.append("');");
 
         try
@@ -530,6 +531,8 @@ public class ItemDataAccess
                 dest = destaque == 9 ? true : false;
 
                 item.setDestaque(dest);
+
+                item.setDestaqueTipo(destaque);
 
                 StringBuilder sb = new StringBuilder();
                 sb.delete(0, this.sBuilder.length());
@@ -803,6 +806,8 @@ public class ItemDataAccess
                 dest = destaque == 9 ? true : false;
 
                 item.setDestaque(dest);
+
+                item.setDestaqueTipo(destaque);
 
                 StringBuilder sb = new StringBuilder();
                 sb.delete(0, this.sBuilder.length());
@@ -1125,6 +1130,8 @@ public class ItemDataAccess
                 dest = destaque == 9 ? true : false;
 
                 item.setDestaque(dest);
+
+                item.setDestaqueTipo(destaque);
 
                 StringBuilder sb = new StringBuilder();
                 sb.delete(0, this.sBuilder.length());
@@ -1466,6 +1473,8 @@ public class ItemDataAccess
 
                 item.setDestaque(dest);
 
+                item.setDestaqueTipo(destaque);
+
                 StringBuilder sb = new StringBuilder();
                 sb.delete(0, this.sBuilder.length());
                 sb.append("SELECT * FROM ");
@@ -1758,6 +1767,8 @@ public class ItemDataAccess
 
                 item.setDestaque(dest);
 
+                item.setDestaqueTipo(destaque);
+
                 StringBuilder sb = new StringBuilder();
                 sb.delete(0, sb.length());
                 sb.append("SELECT * FROM ");
@@ -1926,6 +1937,8 @@ public class ItemDataAccess
 
                 item.setDestaque(dest);
 
+                item.setDestaqueTipo(destaque);
+
                 StringBuilder sb = new StringBuilder();
                 sb.delete(0, this.sBuilder.length());
                 sb.append("SELECT * FROM ");
@@ -2019,6 +2032,7 @@ public class ItemDataAccess
         i.setContribuicao(Float.parseFloat(item.substring(151, 157)) / 1000);
         i.setCusto(Float.parseFloat(item.substring(143, 151)) / 100);
         i.setDestaque(d == 9 ? true : false);
+        i.setDestaqueTipo(d);
 
         return i;
     }

--- a/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/views/Inicial.java
+++ b/SulpassoMobile/app/src/main/java/br/com/sulpasso/sulpassomobile/views/Inicial.java
@@ -193,9 +193,10 @@ public class Inicial extends AppCompatActivity
         }
         else
         {
-//            this.serviceIntialize();
             if(validar_data_sistema(4))
             {
+
+                this.serviceIntialize();
                 if(this.acessoConfirmado)
                 {
                     this.fragmentoCentral();


### PR DESCRIPTION
Modificação da leitura do PW para aceitar quatro status no lugar de
apenas dois. Os status são 0 - Normal, 1 - Foco, 2 - Mix e 9 - Destaque;
essas alterações influenciam a forma como o item é exibido na lista de
consulta de itens na realização do pedido.
Também foi reativado a criação e envios dos arquivos de relatório sendo
necessário identificar uma melhor estratégia para criar, transmitir e
manter essas informações.